### PR TITLE
Change reports output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 .DS_Store
 .idea
-output/**/*.html
 sitemaps.txt

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ To see all available options and arguments run `wp-pa11y --help`.
 
 ### From git clone (using `make`)
 
-| command     | Description                                            |
-| ----------- | ------------------------------------------------------ |
-| `make html` | Generates HTML reports to `./output/{domain}/` folder. |
-| `make cli`  | Outputs reports to cli.                                |
+| command     | Description                                              |
+| ----------- | -------------------------------------------------------- |
+| `make html` | Generates HTML reports to `./wp-pa11y/{domain}/` folder. |
+| `make cli`  | Outputs reports to cli.                                  |
 
 ## Contributors
 

--- a/wp-pa11y.js
+++ b/wp-pa11y.js
@@ -4,15 +4,14 @@ const fetch = require("node-fetch");
 const fs = require("fs");
 const https = require("https");
 const pa11y = require("pa11y");
-const htmlReporter = require('pa11y/lib/reporters/html');
-const cliReporter = require('pa11y/lib/reporters/cli');
+const htmlReporter = require("pa11y/lib/reporters/html");
+const cliReporter = require("pa11y/lib/reporters/cli");
 const path = require("path");
 const puppeteer = require("puppeteer");
 const { XMLParser } = require("fast-xml-parser");
 const { program, Option } = require("commander");
 
 // Configuration.
-const outputDir = path.resolve(__dirname, "output");
 const pkg = require("./package.json");
 const name = "wp-pa11y";
 const version = pkg.version || "0.0.0";
@@ -30,6 +29,13 @@ if (searchedFor === null || searchedFor.isEmpty) {
         "Could not find configuration. Please check docs and try again."
     );
     process.exit(1);
+}
+
+// Create base folder for reports to same path as config file.
+const configDir = path.dirname(searchedFor.filepath);
+const outputDir = path.resolve(configDir, `.${name}`);
+if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir);
 }
 
 const config = cosmicConfig.load(searchedFor.filepath);


### PR DESCRIPTION
Create base folder for reports in the same directory the project-specific `package.json` is located.